### PR TITLE
Fix deprecation warnings for "new Integer/Boolean"

### DIFF
--- a/src/EDU/purdue/jtb/jtbgram.jtb
+++ b/src/EDU/purdue/jtb/jtbgram.jtb
@@ -650,7 +650,7 @@ void OptionBinding() :
   }
   "="
   (
-    int_val = IntegerLiteral()    {      Options.setInputFileOption(t, getToken(0), option_name, new Integer(int_val));    }  | bool_val = BooleanLiteral()    {      Options.setInputFileOption(t, getToken(0), option_name, new Boolean(bool_val));    }  | string_val = StringLiteral()    {      Options.setInputFileOption(t, getToken(0), option_name, string_val);    }
+    int_val = IntegerLiteral()    {      Options.setInputFileOption(t, getToken(0), option_name, Integer.valueOf(int_val));    }  | bool_val = BooleanLiteral()    {      Options.setInputFileOption(t, getToken(0), option_name, Boolean.valueOf(bool_val));    }  | string_val = StringLiteral()    {      Options.setInputFileOption(t, getToken(0), option_name, string_val);    }
   )
   ";"
 }

--- a/src/EDU/purdue/jtb/misc/FieldNameGenerator.java
+++ b/src/EDU/purdue/jtb/misc/FieldNameGenerator.java
@@ -122,11 +122,11 @@ public class FieldNameGenerator {
       Integer suffix = nameTable.get(prefix);
 
       if (suffix == null) {
-        suffix = new Integer(0);
+        suffix = Integer.valueOf(0);
         nameTable.put(prefix, suffix);
         return prefix;
       } else {
-        suffix = new Integer(suffix.intValue() + 1);
+        suffix = Integer.valueOf(suffix.intValue() + 1);
         nameTable.put(prefix, suffix);
         return prefix + suffix.toString();
       }

--- a/src/EDU/purdue/jtb/parser/JavaCCParserInternals.java
+++ b/src/EDU/purdue/jtb/parser/JavaCCParserInternals.java
@@ -41,7 +41,7 @@ public abstract class JavaCCParserInternals extends JavaCCGlobals {
 
   /** Initializes */
   static protected void initialize() {
-    final Integer i = new Integer(0);
+    final Integer i = Integer.valueOf(0);
     lexstate_S2I.put("DEFAULT", i);
     lexstate_I2S.put(i, "DEFAULT");
     simple_tokens_table.put("DEFAULT",
@@ -140,7 +140,7 @@ public abstract class JavaCCParserInternals extends JavaCCGlobals {
         }
       }
       if (lexstate_S2I.get(p.lexStates[i]) == null) {
-        ii = new Integer(nextFreeLexState++);
+        ii = Integer.valueOf(nextFreeLexState++);
         lexstate_S2I.put(p.lexStates[i], ii);
         lexstate_I2S.put(ii, p.lexStates[i]);
         simple_tokens_table.put(p.lexStates[i],

--- a/src/EDU/purdue/jtb/parser/LookaheadCalc.java
+++ b/src/EDU/purdue/jtb/parser/LookaheadCalc.java
@@ -84,7 +84,7 @@ public class LookaheadCalc extends JavaCCGlobals {
         ret += " <EOF>";
       }
       else {
-        final RegularExpression_ re = rexps_of_tokens.get(new Integer(m.match[i]));
+        final RegularExpression_ re = rexps_of_tokens.get(Integer.valueOf(m.match[i]));
         if (re instanceof RStringLiteral) {
           ret += " \"" + add_escapes(((RStringLiteral) re).image) + "\"";
         }

--- a/src/EDU/purdue/jtb/parser/NfaState.java
+++ b/src/EDU/purdue/jtb/parser/NfaState.java
@@ -842,7 +842,7 @@ public class NfaState {
 
           if (!AllBitsSet(tmp))
             out.println("static final long[] jjbitVec" + lohiByteCnt + " = " + tmp);
-          lohiByteTab.put(tmp, ind = new Integer(lohiByteCnt++));
+          lohiByteTab.put(tmp, ind = Integer.valueOf(lohiByteCnt++));
         }
 
         tmpIndices[cnt++] = ind.intValue();
@@ -855,7 +855,7 @@ public class NfaState {
 
           if (!AllBitsSet(tmp))
             out.println("static final long[] jjbitVec" + lohiByteCnt + " = " + tmp);
-          lohiByteTab.put(tmp, ind = new Integer(lohiByteCnt++));
+          lohiByteTab.put(tmp, ind = Integer.valueOf(lohiByteCnt++));
         }
 
         tmpIndices[cnt++] = ind.intValue();
@@ -894,13 +894,13 @@ public class NfaState {
 
           if (!AllBitsSet(tmp))
             out.println("static final long[] jjbitVec" + lohiByteCnt + " = " + tmp);
-          lohiByteTab.put(tmp, ind = new Integer(lohiByteCnt++));
+          lohiByteTab.put(tmp, ind = Integer.valueOf(lohiByteCnt++));
         }
 
         if (loByteVec == null)
           loByteVec = new Vector<Integer>();
 
-        loByteVec.add(new Integer(i));
+        loByteVec.add(Integer.valueOf(i));
         loByteVec.add(ind);
       }
     }
@@ -987,7 +987,7 @@ public class NfaState {
                           stateSetString);
 
     if (nameSet.length == 1) {
-      stateNameToReturn = new Integer(nameSet[0]);
+      stateNameToReturn = Integer.valueOf(nameSet[0]);
       stateNameForComposite.put(stateSetString, stateNameToReturn);
       return nameSet[0];
     }
@@ -1029,7 +1029,7 @@ public class NfaState {
     } else
       tmp = nameSet[toRet];
 
-    stateNameToReturn = new Integer(tmp);
+    stateNameToReturn = Integer.valueOf(tmp);
     stateNameForComposite.put(stateSetString, stateNameToReturn);
     compositeStateTable.put(stateSetString, nameSet);
 

--- a/src/EDU/purdue/jtb/parser/Options.java
+++ b/src/EDU/purdue/jtb/parser/Options.java
@@ -123,7 +123,7 @@ public class Options {
     optionValues.put("BUILD_PARSER", Boolean.TRUE);
     optionValues.put("BUILD_TOKEN_MANAGER", Boolean.TRUE);
     optionValues.put("CACHE_TOKENS", Boolean.FALSE);
-    optionValues.put("CHOICE_AMBIGUITY_CHECK", new Integer(2));
+    optionValues.put("CHOICE_AMBIGUITY_CHECK", Integer.valueOf(2));
     optionValues.put("COMMON_TOKEN_ACTION", Boolean.FALSE);
     optionValues.put("DEBUG_LOOKAHEAD", Boolean.FALSE);
     optionValues.put("DEBUG_PARSER", Boolean.FALSE);
@@ -139,10 +139,10 @@ public class Options {
     optionValues.put("JAVA_UNICODE_ESCAPE", Boolean.FALSE);
     optionValues.put("JDK_VERSION", "1.5");
     optionValues.put("KEEP_LINE_COLUMN", Boolean.TRUE);
-    optionValues.put("LOOKAHEAD", new Integer(1));
+    optionValues.put("LOOKAHEAD", Integer.valueOf(1));
     optionValues.put("NODE_PREFIX", "");
     optionValues.put("NODE_SUFFIX", "");
-    optionValues.put("OTHER_AMBIGUITY_CHECK", new Integer(1));
+    optionValues.put("OTHER_AMBIGUITY_CHECK", Integer.valueOf(1));
     optionValues.put("OUTPUT_DIRECTORY", ".");
     optionValues.put("SANITY_CHECK", Boolean.TRUE);
     optionValues.put("STATIC", Boolean.TRUE);
@@ -156,19 +156,19 @@ public class Options {
     // JTB Options (with default values or command line arguments)
     // -h & -si are not managed in an input file
     if (optionValues.get("JTB_CL") == null)
-      optionValues.put("JTB_CL", new Boolean(printClassList));
+      optionValues.put("JTB_CL", Boolean.valueOf(printClassList));
     if (optionValues.get("JTB_D") == null)
       optionValues.put("JTB_D", "");
     if (optionValues.get("JTB_DL") == null)
-      optionValues.put("JTB_DL", new Boolean(depthLevel));
+      optionValues.put("JTB_DL", Boolean.valueOf(depthLevel));
     if (optionValues.get("JTB_E") == null)
-      optionValues.put("JTB_E", new Boolean(noSemanticCheck));
+      optionValues.put("JTB_E", Boolean.valueOf(noSemanticCheck));
     if (optionValues.get("JTB_F") == null)
-      optionValues.put("JTB_F", new Boolean(descriptiveFieldNames));
+      optionValues.put("JTB_F", Boolean.valueOf(descriptiveFieldNames));
     if (optionValues.get("JTB_IA") == null)
-      optionValues.put("JTB_IA", new Boolean(inlineAcceptMethods));
+      optionValues.put("JTB_IA", Boolean.valueOf(inlineAcceptMethods));
     if (optionValues.get("JTB_JD") == null)
-      optionValues.put("JTB_JD", new Boolean(javaDocComments));
+      optionValues.put("JTB_JD", Boolean.valueOf(javaDocComments));
     if (optionValues.get("JTB_ND") == null)
       optionValues.put("JTB_ND", nodesDirName);
     if (optionValues.get("JTB_NP") == null)
@@ -184,13 +184,13 @@ public class Options {
     if (optionValues.get("JTB_P") == null)
       optionValues.put("JTB_P", "");
     if (optionValues.get("JTB_PP") == null)
-      optionValues.put("JTB_PP", new Boolean(parentPointer));
+      optionValues.put("JTB_PP", Boolean.valueOf(parentPointer));
     if (optionValues.get("JTB_PRINTER") == null)
-      optionValues.put("JTB_PRINTER", new Boolean(printerToolkit));
+      optionValues.put("JTB_PRINTER", Boolean.valueOf(printerToolkit));
     if (optionValues.get("JTB_SCHEME") == null)
-      optionValues.put("JTB_SCHEME", new Boolean(schemeToolkit));
+      optionValues.put("JTB_SCHEME", Boolean.valueOf(schemeToolkit));
     if (optionValues.get("JTB_TK") == null)
-      optionValues.put("JTB_TK", new Boolean(keepSpecialTokens));
+      optionValues.put("JTB_TK", Boolean.valueOf(keepSpecialTokens));
     if (optionValues.get("JTB_VA") == null)
       optionValues.put("JTB_VA", Boolean.FALSE);
     if (optionValues.get("JTB_VD") == null)
@@ -198,7 +198,7 @@ public class Options {
     if (optionValues.get("JTB_VP") == null)
       optionValues.put("JTB_VP", visitorsPackageName);
     if (optionValues.get("JTB_W") == null)
-      optionValues.put("JTB_W", new Boolean(noOverwrite));
+      optionValues.put("JTB_W", Boolean.valueOf(noOverwrite));
   }
 
   /**
@@ -349,7 +349,7 @@ public class Options {
             System.out.println("Warning: Bad option value in \"" + arg + "\" will be ignored.");
             return;
           }
-          val = new Integer(i);
+          val = Integer.valueOf(i);
         }
         catch (final NumberFormatException e) {
           val = s.substring(index + 1);

--- a/src/EDU/purdue/jtb/parser/ParseEngine.java
+++ b/src/EDU/purdue/jtb/parser/ParseEngine.java
@@ -340,7 +340,7 @@ public class ParseEngine extends JavaCCGlobals {
                 final int j1 = i / 32;
                 final int j2 = i % 32;
                 tokenMask[j1] |= 1 << j2;
-                final String s = (names_of_tokens.get(new Integer(i)));
+                final String s = (names_of_tokens.get(Integer.valueOf(i)));
                 if (s == null) {
                   retval.append(i);
                 } else {
@@ -566,7 +566,7 @@ public class ParseEngine extends JavaCCGlobals {
       }
       final String tail = e_nrw.rhsToken == null ? ");" : ")." + e_nrw.rhsToken.image + ";";
       if (e_nrw.label.equals("")) {
-        final Object label = names_of_tokens.get(new Integer(e_nrw.ordinal));
+        final Object label = names_of_tokens.get(Integer.valueOf(e_nrw.ordinal));
         if (label != null) {
           retval += "jj_consume_token(" + (String) label + tail;
         } else {
@@ -903,7 +903,7 @@ public class ParseEngine extends JavaCCGlobals {
     if (e instanceof RegularExpression_) {
       final RegularExpression_ e_nrw = (RegularExpression_) e;
       if (e_nrw.label.equals("")) {
-        final Object label = names_of_tokens.get(new Integer(e_nrw.ordinal));
+        final Object label = names_of_tokens.get(Integer.valueOf(e_nrw.ordinal));
         if (label != null) {
           out.println("    if (jj_scan_token(" + (String) label + ")) " + genReturn(true));
         } else {

--- a/src/EDU/purdue/jtb/parser/Semanticize.java
+++ b/src/EDU/purdue/jtb/parser/Semanticize.java
@@ -300,10 +300,10 @@ public class Semanticize extends JavaCCGlobals {
           res.rexp.ordinal = tokenCount++;
         }
         if (!(res.rexp instanceof RJustName) && !res.rexp.label.equals("")) {
-          names_of_tokens.put(new Integer(res.rexp.ordinal), res.rexp.label);
+          names_of_tokens.put(Integer.valueOf(res.rexp.ordinal), res.rexp.label);
         }
         if (!(res.rexp instanceof RJustName)) {
-          rexps_of_tokens.put(new Integer(res.rexp.ordinal), res.rexp);
+          rexps_of_tokens.put(Integer.valueOf(res.rexp.ordinal), res.rexp);
         }
       }
     }
@@ -357,7 +357,7 @@ public class Semanticize extends JavaCCGlobals {
               jn.ordinal = tokenCount++;
               named_tokens_table.put(jn.label, jn);
               ordered_named_tokens.add(jn);
-              names_of_tokens.put(new Integer(jn.ordinal), jn.label);
+              names_of_tokens.put(Integer.valueOf(jn.ordinal), jn.label);
             } else {
               jn.ordinal = rexp.ordinal;
               prepareToRemove(respecs, res);
@@ -380,7 +380,7 @@ public class Semanticize extends JavaCCGlobals {
         final List<RegExprSpec_> respecs = tp.respecs;
         for (final Iterator<RegExprSpec_> it1 = respecs.iterator(); it1.hasNext();) {
           final RegExprSpec_ res = (it1.next());
-          final Integer ii = new Integer(res.rexp.ordinal);
+          final Integer ii = Integer.valueOf(res.rexp.ordinal);
           if (names_of_tokens.get(ii) == null) {
             JavaCCErrors.warning(res.rexp, "Unlabeled regular expression cannot be referred to by "
                                            + "user generated token manager.");


### PR DESCRIPTION
Fixes warnings such as this:
```
src/EDU/purdue/jtb/parser/JavaCCParserInternals.java:44: warning: [removal] Integer(int) in Integer has been deprecated and marked for removal
    final Integer i = new Integer(0);
                      ^
```
